### PR TITLE
Only refresh atlas when releasing epsilon slider

### DIFF
--- a/SpriteSheetPacker/MainWindow.cpp
+++ b/SpriteSheetPacker/MainWindow.cpp
@@ -786,9 +786,16 @@ void MainWindow::on_spriteBorderSpinBox_valueChanged(int) {
     setProjectDirty();
 }
 
-void MainWindow::on_epsilonHorizontalSlider_valueChanged(int) {
-    propertiesValueChanged();
-    setProjectDirty();
+void MainWindow::on_epsilonHorizontalSlider_sliderMoved(int) {
+    _epsilonValueChanged = true;
+}
+
+void MainWindow::on_epsilonHorizontalSlider_sliderReleased() {
+    if (_epsilonValueChanged) {
+        propertiesValueChanged();
+        setProjectDirty();
+        _epsilonValueChanged = false;
+    }
 }
 
 void MainWindow::on_algorithmComboBox_currentTextChanged(const QString& text) {

--- a/SpriteSheetPacker/MainWindow.h
+++ b/SpriteSheetPacker/MainWindow.h
@@ -59,7 +59,8 @@ private slots:
     void on_algorithmComboBox_currentTextChanged(const QString& text);
     void on_trimModeComboBox_currentIndexChanged(int value);
     void on_trimSpinBox_valueChanged(int value);
-    void on_epsilonHorizontalSlider_valueChanged(int value);
+    void on_epsilonHorizontalSlider_sliderMoved(int value);
+    void on_epsilonHorizontalSlider_sliderReleased();
     void on_textureBorderSpinBox_valueChanged(int value);
     void on_spriteBorderSpinBox_valueChanged(int value);
     void on_imageFormatComboBox_currentIndexChanged(int index);
@@ -93,6 +94,7 @@ private:
     bool                    _projectDirty;
     bool                    _atlasDirty;
     bool                    _needFitAfterRefresh;
+    bool                    _epsilonValueChanged;
 
     QFuture<bool>           _future;
     QFutureWatcher<bool>    _watcher;


### PR DESCRIPTION
Every time you slide the epsilon slider the atlas is rebuild for every epsilon value. Now the atlas only gets built for the last value.