### PR TITLE
[fix] Open animation preview bug 

### DIFF
--- a/SpriteSheetPacker/AnimationPreviewDialog.cpp
+++ b/SpriteSheetPacker/AnimationPreviewDialog.cpp
@@ -11,6 +11,7 @@ AnimationPreviewDialog::AnimationPreviewDialog(SpritesTreeWidget* spritesTreeWid
     ui(new Ui::AnimationPreviewDialog),
     _spritesTreeWidget(spritesTreeWidget)
 {
+    setAttribute(Qt::WA_DeleteOnClose);
     ui->setupUi(this);
 
     _instance = this;

--- a/SpriteSheetPacker/MainWindow.cpp
+++ b/SpriteSheetPacker/MainWindow.cpp
@@ -771,7 +771,6 @@ void MainWindow::on_actionAnimationPreview_triggered() {
     if (AnimationPreviewDialog::instance()) {
         auto dlg = AnimationPreviewDialog::instance();
         dlg->close();
-        delete dlg;
         return;
     }
 


### PR DESCRIPTION
Once you open the animation preview window and close it, you had to press animation preview twice to open it again