### PR TITLE
Avoid error if format is unset

### DIFF
--- a/SpriteSheetPacker/PublishSpriteSheet.cpp
+++ b/SpriteSheetPacker/PublishSpriteSheet.cpp
@@ -190,7 +190,7 @@ bool PublishSpriteSheet::publish(const QString& format, bool errorMessage) {
             outputFilePaths.push_back(outputFilePath);
 
             // generate the data file and the image
-            if (!generateDataFile(outputFilePath, format, outputData._spriteFrames, outputData._atlasImage, errorMessage)) {
+            if (!format.isEmpty() && !generateDataFile(outputFilePath, format, outputData._spriteFrames, outputData._atlasImage, errorMessage)) {
                 return false;
             }
 


### PR DESCRIPTION
Hi

The first time I ran the app I had no format but I still wanted to generate the image file.

This PR allows the generation of the image file only