### PR TITLE
Added ssp extension automatically for saving project in linux

### DIFF
--- a/SpriteSheetPacker/MainWindow.cpp
+++ b/SpriteSheetPacker/MainWindow.cpp
@@ -577,7 +577,11 @@ void MainWindow::on_actionSaveAs_triggered() {
     QString fileName = QFileDialog::getSaveFileName(this, tr("Save sprite packer project file."),
                                                     dir,
                                                     tr("Sprite sheet packer (*.ssp)"));
+    QFileInfo info(fileName);
     if (!fileName.isEmpty()) {
+        if (info.suffix() != "ssp") {
+          fileName.append(".ssp");
+        }
         settings.setValue("spritePackerFileName", fileName);
         saveSpritePackerProject(fileName);
     }


### PR DESCRIPTION
In linux, file dialog doesn't add extension when saving, that caused save
project crash. Fixes #72 