### PR TITLE
Add CI for Linux & macOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
         mkdir -p $GITHUB_WORKSPACE/bin
         mv linuxdeployqt-continuous-x86_64.AppImage $GITHUB_WORKSPACE/bin/linuxdeployqt
         chmod +x $GITHUB_WORKSPACE/bin/linuxdeployqt
-        echo "::add-path::$GITHUB_WORKSPACE/bin"
+        echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
 
     - name: Run QMake
       run: qmake sprite-sheet-packer.pro

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,39 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  macos:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Cache Qt
+      id: cache-qt
+      uses: actions/cache@v1
+      with:
+        path: ../Qt
+        key: ${{ runner.os }}-QtCache
+
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v2
+      with:
+        cached: ${{ steps.cache-qt.outputs.cache-hit }}
+
+    - name: Run QMake
+      run: qmake sprite-sheet-packer.pro
+
+    - name: Build
+      run: |
+        make -j8
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: SpriteSheetPacker-macos
+        path: |
+          ./*.dmg
+          ./**/*.dmg
+
+  linux:
     runs-on: ubuntu-16.04
 
     steps:
@@ -53,7 +85,7 @@ jobs:
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: SpriteSheetPacker
+        name: SpriteSheetPacker-linux
         path: |
           ./*.AppImage
           ./**/*.AppImage

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,59 @@
+name: SpritesheetPacker
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-16.04
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Cache Qt
+      id: cache-qt
+      uses: actions/cache@v1
+      with:
+        path: ../Qt
+        key: ${{ runner.os }}-QtCache
+
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v2
+      with:
+        cached: ${{ steps.cache-qt.outputs.cache-hit }}
+
+    - name: Download linuxdeployqt
+      run: |
+        wget https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage
+        mkdir -p $GITHUB_WORKSPACE/bin
+        mv linuxdeployqt-continuous-x86_64.AppImage $GITHUB_WORKSPACE/bin/linuxdeployqt
+        chmod +x $GITHUB_WORKSPACE/bin/linuxdeployqt
+        echo "::add-path::$GITHUB_WORKSPACE/bin"
+
+    - name: Run QMake
+      run: qmake sprite-sheet-packer.pro
+
+    - name: Create AppDir
+      run: |
+        mkdir -p AppDir/usr/bin
+        mkdir -p AppDir/usr/lib
+        mkdir -p AppDir/usr/share/applications
+        mkdir -p AppDir/usr/share/icons/hicolor/256x256/apps
+        cp install/linux/SpriteSheetPacker.desktop AppDir/usr/share/applications/
+        cp SpriteSheetPacker/res/icon.png AppDir/usr/share/icons/hicolor/256x256/apps/SpriteSheetPacker.png
+
+    - name: Build
+      run: |
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/SpriteSheetPacker/3rdparty/PVRTexTool/Linux_x86_64
+        make -j8
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: SpriteSheetPacker
+        path: |
+          ./*.AppImage
+          ./**/*.AppImage

--- a/SpriteSheetPacker/SpriteSheetPacker.pro
+++ b/SpriteSheetPacker/SpriteSheetPacker.pro
@@ -15,7 +15,7 @@ CONFIG += c++11
 CONFIG(release,debug|release) {
     win32: DESTDIR = $$PWD/../install/win/bin
     macx: DESTDIR = $$PWD/../install/macos/bin
-    linux: DESTDIR = $$PWD/../install/linux/bin
+    linux: DESTDIR = $$PWD/../AppDir/usr/bin
 } else {
     macx: DESTDIR = $$OUT_PWD
     win32: DESTDIR = $$OUT_PWD/debug
@@ -129,14 +129,20 @@ CONFIG(release,debug|release) {
     win32 {
         DEPLOY_COMMAND = windeployqt
         isEmpty(TARGET_EXT) TARGET_EXT = .exe
+        DEPLOY_TARGET = $$shell_quote($$shell_path($${DESTDIR}/$${TARGET}$${TARGET_EXT}))
     }
 
     macx {
         DEPLOY_COMMAND = macdeployqt
         isEmpty(TARGET_EXT) TARGET_EXT = .app
+        DEPLOY_TARGET = $$shell_quote($$shell_path($${DESTDIR}/$${TARGET}$${TARGET_EXT}))
     }
 
-    DEPLOY_TARGET = $$shell_quote($$shell_path($${DESTDIR}/$${TARGET}$${TARGET_EXT}))
+    linux {
+        DEPLOY_COMMAND = linuxdeployqt
+        DEPLOY_TARGET = ../AppDir/usr/share/applications/$${TARGET}.desktop
+        DEPLOY_OPTIONS = -appimage
+    }
 
-    QMAKE_POST_LINK = $${DEPLOY_COMMAND} $${DEPLOY_TARGET}
+    QMAKE_POST_LINK = $${DEPLOY_COMMAND} $${DEPLOY_TARGET} $${DEPLOY_OPTIONS}
 }

--- a/SpriteSheetPacker/SpriteSheetPacker.pro
+++ b/SpriteSheetPacker/SpriteSheetPacker.pro
@@ -133,10 +133,10 @@ CONFIG(release,debug|release) {
     }
 
     macx {
-        DEPLOY_COMMAND = macdeployqt
+        DEPLOY_PATH = $$shell_quote($$shell_path($${DESTDIR}))
         isEmpty(TARGET_EXT) TARGET_EXT = .app
-        DEPLOY_TARGET = $$shell_quote($$shell_path($${DESTDIR}/$${TARGET}$${TARGET_EXT}))
         DEPLOY_OPTIONS = -dmg
+        DEPLOY_COMMAND = "cd $${DEPLOY_PATH} && macdeployqt $${TARGET}$${TARGET_EXT}"
     }
 
     linux {

--- a/SpriteSheetPacker/SpriteSheetPacker.pro
+++ b/SpriteSheetPacker/SpriteSheetPacker.pro
@@ -136,6 +136,7 @@ CONFIG(release,debug|release) {
         DEPLOY_COMMAND = macdeployqt
         isEmpty(TARGET_EXT) TARGET_EXT = .app
         DEPLOY_TARGET = $$shell_quote($$shell_path($${DESTDIR}/$${TARGET}$${TARGET_EXT}))
+        DEPLOY_OPTIONS = -dmg
     }
 
     linux {

--- a/install/linux/SpriteSheetPacker.desktop
+++ b/install/linux/SpriteSheetPacker.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Name=SpriteSheetPacker
+Comment=
+Exec=SpriteSheetPacker
+Icon=SpriteSheetPacker
+# available categories, see: https://specifications.freedesktop.org/menu-spec/latest/apa.html
+Categories=Utility;


### PR DESCRIPTION
Hello,

I hope this is useful. It automatically creates packages for macOS & Linux (DMG for macOS, AppImage for Linux) on every commit to master using Github Actions (the tab here on top). A nice badge can be added on the readme for people to be able to download the builds or something similar, but I'll leave the niceties for somebody else if you accept this PR :).

Also, a Windows build is missing. Should be a matter of mostly copying what the macOS build is doing. And the commits are separate (more or less) in case you want to add only Linux or only macOS support for any reason :).

Finally, this is not perfect and can be improved a lot, but I've already spent too much time on it already :).